### PR TITLE
Update Docker-compose with last working version on AWS.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'v*' ]
     tags: ['*']
 
 

--- a/apps/box/package.json
+++ b/apps/box/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@functionland/box",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Reference implementation of box server in Node.js",
   "main": "dist/index.js",
   "bin": "./cli.js",

--- a/apps/cluster/docker-compose.yaml
+++ b/apps/cluster/docker-compose.yaml
@@ -3,22 +3,19 @@ version: '3.8'
 services:
   box0:
     container_name: box0
+    image: functionland/box:v0.6.5
     restart: always
     depends_on:
       - ipfs0
       - cluster0
-    build:
-      context: ../../
-      dockerfile: ./apps/box/Dockerfile
     volumes:
       - ./data/box0/data:/opt/apps/box/data
     environment:
+      DEBUG: "box:*"
       NODE_ENV: "production"
-      FULA_CLUSTER_PROXY: "http://cluster0:9095"
-      FULA_IPFS_HTTP: "http://ipfs0:5001"
-    ports:
-      - "4002:4002" # TCP
-      - "4003:4003" # WS
+      FULA_CLUSTER_PROXY: "http://localhost:9095"
+      FULA_IPFS_HTTP: "http://localhost:5001"
+    network_mode: "host"
 
   ipfs0:
     container_name: ipfs0
@@ -59,16 +56,15 @@ services:
 
   box1:
     container_name: box1
+    image: functionland/box:v0.6.5
     restart: always
     depends_on:
       - ipfs1
       - cluster1
-    build:
-      context: ../../
-      dockerfile: ./apps/box/Dockerfile
     volumes:
       - ./data/box1/data:/opt/apps/box/data
     environment:
+      DEBUG: "box:*"
       NODE_ENV: "production"
       FULA_CLUSTER_PROXY: "http://cluster1:9095"
       FULA_IPFS_HTTP: "http://ipfs1:5001"


### PR DESCRIPTION
Set box debugging level to trace so user report better error's
Add v* to build and publish, so we can test the outcome before merge and tag.
Bump box version.